### PR TITLE
Release 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-theme-swapper",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "src/index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Apparently can't have the `v`.