### PR TITLE
Simplify transparency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwindcss-theme-swapper",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwindcss-theme-swapper",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "postcss": "^8.4.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-theme-swapper",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,7 @@ function toConfigValue (keys, value) {
   }
 
   if (colorConfigKeys.includes(keys[0])) {
-    return `color-mix(in srgb, var(--${getTailwindKeyName(keys)}), transparent calc(100% - 100% * <alpha-value>))`
+    return `color-mix(in srgb, var(--${getTailwindKeyName(keys)}) calc(100% * <alpha-value>), transparent)`
   }
 
   return `var(--${getTailwindKeyName(keys)})`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,11 +76,11 @@ postcss(tailwindcss({
       expect(resolvedConfig).toMatchObject({
         "theme": {
           "colors": {
-            "with-opacity": "color-mix(in srgb, var(--colors-with-opacity), transparent calc(100% - 100% * <alpha-value>))",
-            "hotpink": "color-mix(in srgb, var(--colors-hotpink), transparent calc(100% - 100% * <alpha-value>))",
+            "with-opacity": "color-mix(in srgb, var(--colors-with-opacity) calc(100% * <alpha-value>), transparent)",
+            "hotpink": "color-mix(in srgb, var(--colors-hotpink) calc(100% * <alpha-value>), transparent)",
             "primary": {
-              "default": "color-mix(in srgb, var(--colors-primary), transparent calc(100% - 100% * <alpha-value>))",
-              "darker": "color-mix(in srgb, var(--colors-primary-darker), transparent calc(100% - 100% * <alpha-value>))",
+              "default": "color-mix(in srgb, var(--colors-primary) calc(100% * <alpha-value>), transparent)",
+              "darker": "color-mix(in srgb, var(--colors-primary-darker) calc(100% * <alpha-value>), transparent)",
             }
           },
           "spacing": {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -121,10 +121,10 @@ describe('getThemeAsCustomProps', () => {
 
       expect(result).toEqual({
         colors: {
-          red: "color-mix(in srgb, var(--colors-red), transparent calc(100% - 100% * <alpha-value>))",
+          red: "color-mix(in srgb, var(--colors-red) calc(100% * <alpha-value>), transparent)",
           primary: {
-            default: "color-mix(in srgb, var(--colors-primary), transparent calc(100% - 100% * <alpha-value>))",
-            darker: "color-mix(in srgb, var(--colors-primary-darker), transparent calc(100% - 100% * <alpha-value>))",
+            default: "color-mix(in srgb, var(--colors-primary) calc(100% * <alpha-value>), transparent)",
+            darker: "color-mix(in srgb, var(--colors-primary-darker) calc(100% * <alpha-value>), transparent)",
           },
         },
         fontSize: {
@@ -156,7 +156,7 @@ describe('getThemeAsCustomProps', () => {
     })
 
     test('should just return the value when it is not a color', () => {
-      expect(tailwindConfigValueTransformer(['colors', 'primary'], 'rgb(255, 0, 0)')).toEqual('color-mix(in srgb, var(--colors-primary), transparent calc(100% - 100% * <alpha-value>))')
+      expect(tailwindConfigValueTransformer(['colors', 'primary'], 'rgb(255, 0, 0)')).toEqual('color-mix(in srgb, var(--colors-primary) calc(100% * <alpha-value>), transparent)')
       expect(tailwindConfigValueTransformer(['fontSize'], '16px')).toEqual('var(--font-size)')
     })
   })


### PR DESCRIPTION
There seems to be an issue with CSS minifiers and the old approach I used to mix transparency into a color.